### PR TITLE
Fixes "Error: cannot xtfrm data frames" when finding modules in non-parallel mode

### DIFF
--- a/R/fcoex.R
+++ b/R/fcoex.R
@@ -605,6 +605,11 @@ change_dots_for_dashes <- function(vector_of_genes) {
 get_gene_by_gene_correlation_matrix_in_series <-
   function(genes_from_su_ranking,
            expression_table_only_with_genes_with_high_su) {
+    mtx <- factor(as.matrix(expression_table_only_with_genes_with_high_su))
+    dim(mtx) <- dim(expression_table_only_with_genes_with_high_su)
+    dimnames(mtx) <- dimnames(expression_table_only_with_genes_with_high_su)
+    expression_table_only_with_genes_with_high_su <- I(mtx)
+    
     gene_by_gene_su_correlation <-
       data.frame(genes = genes_from_su_ranking)
     


### PR DESCRIPTION
**Description**: `find_cbf_modules` gives an error when running in series/non-parallel mode in R 4.3.

The bug was mentioned in #14. It seems that `as.factor` cannot properly handle dataframe in current version.
https://github.com/csbl-usp/fcoex/blob/7edb01c21a3fdf08fbdd1ca452af551e8ff37966/R/fcoex.R#L617-L620

**Example**: When I was trying to run the following vignette codes on R 4.3.0:
```R
library(Seurat)
library(fcoex)
library(ggplot2)

data(pbmc_small)

exprs <- data.frame(GetAssayData(pbmc_small))
target <- Idents(pbmc_small)

fc <- new_fcoex(data.frame(exprs),target)
fc <- discretize(fc)
fc <- find_cbf_modules(fc,n_genes = 70, verbose = FALSE, is_parallel = TRUE)
fc <- get_nets(fc)
```

An error occured:
> Getting SU scores for each gene
Running FCBF to find module headers
[1] "Number of features features =  230"
[1] "Number of prospective features =  69"
[1] "Number of final features =  9"
Calculating adjacency matrix
Error in xtfrm.data.frame(x) : cannot xtfrm data frames


**Changes**: The `expression_table_only_with_genes_with_high_su` was converted into a two-dimentional factor before the loop.